### PR TITLE
updates License and Contributing links in README for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ The same can be done when you `applyResponsiveStyleModifiers`.
 
 ## Contributing
 
-We are thankful for any contributions made by the community. By contributing you agree to abide by the Code of Conduct in our [Contributing Guidelines](.github/CONTRIBUTING.md).
+We are thankful for any contributions made by the community. By contributing you agree to abide by the Code of Conduct in our [Contributing Guidelines](https://github.com/Decisiv/styled-components-modifiers/blob/master/.github/CONTRIBUTING.md).
 
 ## License
 
-[MIT](LICENSE)
+[MIT](https://github.com/Decisiv/styled-components-modifiers/blob/master/LICENSE)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Decisiv/styled-components-modifiers.git"
+    "url": "https://github.com/Decisiv/styled-components-modifiers.git"
   },
   "keywords": [
     "styled-components",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Decisiv/Development/styled-components-modifiers.git"
+    "url": "git+https://github.com/Decisiv/styled-components-modifiers.git"
   },
   "keywords": [
     "styled-components",


### PR DESCRIPTION
## OVERVIEW
The relative links for Contributing and the MIT license worked on Github, but not on npm. So I updated them to use a full URL.

## WHERE SHOULD THE REVIEWER START?
README.md

## HOW CAN THIS BE MANUALLY TESTED?
* View the README and click the links

## ANY NEW DEPENDENCIES ADDED?
nope.

## CHECKLIST
_Be sure all items are_ ✅ _before submitting a PR for review._
* [x] Verify the linter and tests pass: `npm run review`
* [x] Verify this branch is rebased with the latest master

## GIF
_Share a fun GIF to say thanks to your reviewer:_
https://giphy.com

![](https://media.giphy.com/media/3o7ZeT4XKYLG6x8zqo/giphy.gif)
