### PR TITLE
removes the previously deprecated default styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ const MODIFIER_CONFIG = {
     `,
   }),
 
-  // Prefer standardizing values like sizes or colors in your theme,
-  // and defining modifiers based on theme values and plain CSS only.
   warning: ({ theme }) => `
     background-color: ${theme.colors.warning};
   `,
@@ -103,7 +101,7 @@ import styled from 'styled-components';
 import { applyStyleModifiers } from 'styled-components-modifiers';
 
 const Button = styled.button`
-  // Any styles that won't change or may be over-ruled can go above where you
+  // Any styles that won't change or may be overruled can go above where you
   // apply the style modifiers. In BEM, these would be the styles you apply in
   // either the Block or Element class's primary definition
   font-size: 24px;
@@ -120,7 +118,7 @@ The end result is a block (`Button`) with four available modifiers (`disabled`, 
 
 ## Applying Modifiers
 
-Applying modifiers when rendering the component is as simple as providing a `modifiers` prop. The prop should be an array of strings that must match the keys in the modifier configuration object applied to the component.
+Applying modifiers when rendering the component is as simple as providing a `modifiers` prop. The prop should be an array of strings that correspond to keys in the modifier configuration object applied to the component.
 
 ```jsx
 function Form() {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Our method for structuring Blocks and Elements doesn’t actually require any sp
   const Button = styled.button``;
 
   // Define your Icon styled component (the Element)
-  const Icon = styled(FontAwesome);
+  const Icon = styled(FontAwesome)``;
 
   // Add the Icon as a property of the Button
   Button.Icon = Icon;
@@ -62,7 +62,7 @@ The modifiers are passed in as an array of flags, each of which changes the appe
 
 ## Defining Modifiers
 
-The core of `styled-components-modifiers` is a modifier configuration object. The _keys_ in this object become the available flags that can be passed to the component's `modifiers`  prop. Each _value_ in the configuration object is a function that returns an object with a `styles` key.
+The core of `styled-components-modifiers` is a modifier configuration object. The _keys_ in this object become the available flags that can be passed to the component's `modifiers`  prop. Each _value_ defines a function that returns a CSS style string.
 
 For our demo, let's first set up a modifier configuration object:
 
@@ -70,32 +70,29 @@ For our demo, let's first set up a modifier configuration object:
 const MODIFIER_CONFIG = {
   // The functions receive the props of the component as the only argument.
   // Here, we destructure the theme from the argument for use within the modifier styling.
-  disabled: ({ theme }) => ({
-    // The `styles` in a definition are applied any time the modifier is used.
-    styles: `
-      background-color: ${theme.colors.grey_400};
-      color: ${theme.colors.grey_100};
-    `,
-  }),
+  disabled: ({ theme }) => `
+    // These styles are applied any time this modifier is used.
+    background-color: ${theme.colors.chrome_400};
+    color: ${theme.colors.chrome_100};
+  `,
 
+  // Alternatively, you can return an object with your styles under the key `styles`.
   success: ({ theme }) => ({
     styles: `
       background-color: ${theme.colors.success};
     `,
   }),
 
-  warning: ({ theme }) => ({
-    styles: `
-      background-color: ${theme.colors.warning};
-    `,
-  }),
+  // Prefer standardizing values like sizes or colors in your theme,
+  // and defining modifiers based on theme values and plain CSS only.
+  warning: ({ theme }) => `
+    background-color: ${theme.colors.warning};
+  `,
 
-  large: () => ({
-    styles: `
-      height: 3em;
-      width: 6em;
-    `,
-  }),
+  large: () => `
+    height: 3em;
+    width: 6em;
+  `,
 };
 ```
 
@@ -106,10 +103,9 @@ import styled from 'styled-components';
 import { applyStyleModifiers } from 'styled-components-modifiers';
 
 const Button = styled.button`
-  // Any styles that won't change or may be overruled can go
-  // above where you apply the style modifiers.
-  // In BEM, this would be the styles you apply in either the
-  // Block or Element class's primary definition
+  // Any styles that won't change or may be over-ruled can go above where you
+  // apply the style modifiers. In BEM, these would be the styles you apply in
+  // either the Block or Element class's primary definition
   font-size: 24px;
   padding: 16px
 
@@ -124,7 +120,7 @@ The end result is a block (`Button`) with four available modifiers (`disabled`, 
 
 ## Applying Modifiers
 
-Applying modifiers when rendering the component is as simple as providing a `modifiers` prop. The prop should be an array of strings representing the keys in the modifier configuration object you wish to apply.
+Applying modifiers when rendering the component is as simple as providing a `modifiers` prop. The prop should be an array of strings that must match the keys in the modifier configuration object applied to the component.
 
 ```jsx
 function Form() {
@@ -187,6 +183,7 @@ const Button = styled.button`
 Button.propTypes = {
   // Setup validation of the "normal" modifier flags:
   modifiers: styleModifierPropTypes(MODIFIER_CONFIG),
+
   // You can also validate the responsive modifier flags:
   responsiveModifiers: responsiveStyleModifierPropTypes(MODIFIER_CONFIG),
 }
@@ -208,7 +205,7 @@ Using responsive modifiers is a little bit different, though, but just as simple
 
 It works by matching the `size` prop provided to the component with the keys of the `responsiveModifiers` prop, and then applying the appropriate modifier(s) based on the corresponding value in `responsiveModifiers`.
 
-So, for example, when `Button` receives a prop `size` with a value equal to `medium`, the modifiers `success` and `large` will be applied to the `Button`. If `size` does not match any key in the `responsiveModifiers`, _no_ modifiers will be applied.
+So, for example, when `Button` receives a prop `size` with a value equal to `medium`, the modifiers `success` and `large` will be applied to the `Button`. If `size` does not match any key in the `responsiveModifiers`, _no_ additional modifiers will be applied. Your normal `modifiers` array will still work exactly the same.
 
 Tada! Responsive styling!
 

--- a/lib/__tests__/applyResponsiveStyleModifiers.js
+++ b/lib/__tests__/applyResponsiveStyleModifiers.js
@@ -1,11 +1,13 @@
 import applyResponsiveStyleModifiers from '../applyResponsiveStyleModifiers';
 
 const defaultModifierConfig = {
-  test: () => ({ styles: 'display: relative;' }),
+  test: () => ({
+    styles: 'display: relative;',
+  }),
   themeTest: ({ theme }) => ({
     styles: `background-color: ${theme.colors.text};`,
   }),
-  defaultTest: () => ({ styles: 'color: blue;', defaultStyles: 'color: red;' }),
+  stringTest: () => 'color: blue;',
 };
 
 const theme = {
@@ -30,13 +32,17 @@ test('returns a style string with styles based on size prop', () => {
   expect(styles).not.toContain('display: relative;');
 });
 
-test('returns only defaultStyles with no responsiveModifiers defined', () => {
+test('returns a style string with styles based on size prop and config styles is a string', () => {
   const props = {
-    size: 'SM',
+    responsiveModifiers: {
+      XS: ['stringTest'],
+      SM: ['themeTest'],
+    },
+    size: 'XS',
     theme,
   };
 
   const styles = applyResponsiveStyleModifiers(defaultModifierConfig)(props);
 
-  expect(styles).toEqual('color: red;');
+  expect(styles).toEqual('color: blue;');
 });

--- a/lib/__tests__/applyStyleModifiers.js
+++ b/lib/__tests__/applyStyleModifiers.js
@@ -5,7 +5,7 @@ const defaultModifierConfig = {
   themeTest: ({ theme }) => ({
     styles: `background-color: ${theme.colors.text};`,
   }),
-  defaultTest: () => ({ styles: 'color: blue;', defaultStyles: 'color: red;' }),
+  stringTest: () => 'color: blue;',
 };
 
 const theme = {
@@ -16,24 +16,13 @@ const theme = {
 
 test('applyStyleModifiers returns the expect styles based on modifier prop', () => {
   const props = {
-    modifiers: ['test', 'defaultTest'],
+    modifiers: ['test', 'stringTest'],
     theme,
   };
 
   const styles = applyStyleModifiers(defaultModifierConfig)(props);
 
   expect(styles).toEqual('display: relative; color: blue;');
-});
-
-test('applyStyleModifiers returns the default style when modifier key not present in modifier prop', () => {
-  const props = {
-    modifiers: ['test'],
-    theme,
-  };
-
-  const styles = applyStyleModifiers(defaultModifierConfig)(props);
-
-  expect(styles).toEqual('display: relative; color: red;');
 });
 
 test('applyStyleModifiers returns the expected styles when modifier interpolates from theme', () => {
@@ -44,5 +33,5 @@ test('applyStyleModifiers returns the expected styles when modifier interpolates
 
   const styles = applyStyleModifiers(defaultModifierConfig)(props);
 
-  expect(styles).toEqual('background-color: black; color: red;');
+  expect(styles).toEqual('background-color: black;');
 });

--- a/lib/__tests__/responsiveModifierPropTypes.js
+++ b/lib/__tests__/responsiveModifierPropTypes.js
@@ -26,7 +26,9 @@ test('responsiveStyleModifierPropTypes does not log error with valid modifiers',
   const consoleSpy = jest.spyOn(console, 'error').mockImplementation(noop);
 
   const testPropTypes = {
-    responsiveModifiers: responsiveStyleModifierPropTypes(defaultResponsiveModifierConfig),
+    responsiveModifiers: responsiveStyleModifierPropTypes(
+      defaultResponsiveModifierConfig,
+    ),
   };
   const goodProps = {
     responsiveModifiers: {
@@ -46,7 +48,9 @@ test('responsiveStyleModifierPropTypes logs error with invalid modifier key', ()
   const consoleSpy = jest.spyOn(console, 'error').mockImplementation(noop);
 
   const testPropTypes = {
-    responsiveModifiers: responsiveStyleModifierPropTypes(defaultResponsiveModifierConfig),
+    responsiveModifiers: responsiveStyleModifierPropTypes(
+      defaultResponsiveModifierConfig,
+    ),
   };
   const badProps = {
     responsiveModifiers: {
@@ -56,7 +60,8 @@ test('responsiveStyleModifierPropTypes logs error with invalid modifier key', ()
   };
   PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
 
-  const expectedErrMsg = "Invalid modifier wrongModifier used in prop 'responsiveModifiers' (size key XS) and supplied to MyComponent. Validation failed.";
+  const expectedErrMsg =
+    "Invalid modifier wrongModifier used in prop 'responsiveModifiers' (size key XS) and supplied to MyComponent. Validation failed.";
   expect(consoleSpy).toHaveBeenCalled();
   const errorMsg = consoleSpy.mock.calls[0][0];
   expect(errorMsg).toContain(expectedErrMsg);
@@ -69,7 +74,9 @@ test('responsiveStyleModifierPropTypes logs error with invalid modifier keys', (
   const consoleSpy = jest.spyOn(console, 'error').mockImplementation(noop);
 
   const testPropTypes = {
-    responsiveModifiers: responsiveStyleModifierPropTypes(defaultResponsiveModifierConfig),
+    responsiveModifiers: responsiveStyleModifierPropTypes(
+      defaultResponsiveModifierConfig,
+    ),
   };
   const badProps = {
     responsiveModifiers: {
@@ -79,7 +86,8 @@ test('responsiveStyleModifierPropTypes logs error with invalid modifier keys', (
   };
   PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
 
-  const expectedErrMsg = "Invalid modifiers firstWrongModifier, secondWrongModifier used in prop 'responsiveModifiers' (size keys XS, SM) and supplied to MyComponent. Validation failed.";
+  const expectedErrMsg =
+    "Invalid modifiers firstWrongModifier, secondWrongModifier used in prop 'responsiveModifiers' (size keys XS, SM) and supplied to MyComponent. Validation failed.";
   expect(consoleSpy).toHaveBeenCalled();
   const errorMsg = consoleSpy.mock.calls[0][0];
   expect(errorMsg).toContain(expectedErrMsg);

--- a/lib/utils/__tests__/modifiedStyles.js
+++ b/lib/utils/__tests__/modifiedStyles.js
@@ -1,10 +1,9 @@
 import modifiedStyles from '../modifiedStyles';
 
 const defaultModifierConfig = {
-  themeTest: ({ theme }) => ({
-    styles: `background-color: ${theme.colors.text};`,
-  }),
-  defaultTest: () => ({ styles: 'color: blue;', defaultStyles: 'color: red;' }),
+  objectTest: () => ({ styles: 'color: green;' }),
+  styleString: () => 'color: blue;',
+  themeTest: ({ theme }) => `background-color: ${theme.colors.text};`,
 };
 
 const theme = {
@@ -17,13 +16,15 @@ test('returns an empty string with no args', () => {
   expect(modifiedStyles()).toEqual('');
 });
 
-test('returns a string with defaultStyles when no modifiers given', () => {
-  const styles = modifiedStyles([], defaultModifierConfig, { theme });
-  expect(styles).toContain('color: red');
+test('returns a string with styles when modifier given and config object supplied', () => {
+  const styles = modifiedStyles(['objectTest'], defaultModifierConfig, {
+    theme,
+  });
+  expect(styles).toContain('color: green');
 });
 
-test('returns a string based on styles when modifier given', () => {
-  const styles = modifiedStyles(['defaultTest'], defaultModifierConfig, {
+test('returns a string with styles when modifier given and config string supplied', () => {
+  const styles = modifiedStyles(['styleString'], defaultModifierConfig, {
     theme,
   });
   expect(styles).toContain('color: blue');

--- a/lib/utils/modifiedStyles.js
+++ b/lib/utils/modifiedStyles.js
@@ -1,5 +1,4 @@
-import keys from 'lodash.keys';
-import mapValues from 'lodash.mapvalues';
+import isObject from 'lodash.isobject';
 
 /**
  * Extracts and builds the required style string based on the provided values.
@@ -13,23 +12,11 @@ export default function modifiedStyles(
   modifierConfig = {},
   componentProps = {},
 ) {
-  const modifierValues = mapValues(modifierConfig, config =>
-    config(componentProps),
-  );
-
-  const stylesArr = keys(modifierConfig).reduce((acc, modifierName) => {
-    const config = modifierValues[modifierName];
-    const styles = modifierProps.includes(modifierName)
-      ? config.styles
-      : config.defaultStyles;
-
-    if (process.env.NODE_ENV !== 'production' && config.defaultStyles) {
-      console.warn(
-        `The ${modifierName} config contains defaultStyles. This functionality is deprecated and will be removed in version 0.1.0`,
-      );
-    }
-
-    return styles ? acc.concat([styles]) : acc;
+  const stylesArr = modifierProps.reduce((acc, modifierName) => {
+    const modifierFunc = modifierConfig[modifierName];
+    const config = modifierFunc(componentProps);
+    const styles = isObject(config) ? config.styles : config;
+    return acc.concat(styles);
   }, []);
 
   return stylesArr.join(' ');

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "build:clean": "rimraf ./dist",
     "lint": "eslint lib/**; exit 0",
     "prebuild": "npm run build:clean && npm run lint && npm run test",
-    "prepublish": "npm run build",
     "review": "npm run lint && npm test",
     "test": "jest",
     "test:coverage:report": "opn coverage/lcov-report/index.html",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "lodash.flatten": "^4.4.0",
     "lodash.forin": "^4.4.0",
     "lodash.iserror": "^3.1.1",
+    "lodash.isobject": "^3.0.2",
     "lodash.keys": "^4.2.0",
-    "lodash.mapvalues": "^4.6.0",
     "lodash.uniq": "^4.5.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2599,13 +2599,13 @@ lodash.iserror@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.iserror/-/lodash.iserror-3.1.1.tgz#297b9a05fab6714bc2444d7cc19d1d7c44b5ecec"
 
+lodash.isobject@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+
 lodash.keys@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
-
-lodash.mapvalues@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
 
 lodash.uniq@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
## OVERVIEW
This PR removes the `defaultStyles` functionality entirely, thus simplifying use of the library. Due to how the modifier configurations had to be processed in order to apply `defaultStyles`, significant performance gains were available when this functionality was removed.

An additional enhancement, that may itself be open for further performance enhancements in the future, is that a modifier configuration function no longer needs to return an object with the key styles. Now a simple string or template literal can be returned. As this PR sits now, the returned value is evaluated to determine if it is an object or string, and processed accordingly.

This PR will create a breaking change and require a major version update.

## WHERE SHOULD THE REVIEWER START?
`lib/utils/modifiedStyles.js`

## HOW CAN THIS BE MANUALLY TESTED?
`yarn review`

## ANY NEW DEPENDENCIES ADDED?
`lodash.isobject` - used when evaluating a the return value of a modifier config function to determine if it is an object or a string.
Also, `lodash.mapvalues` was no longer used and has been removed.

## CHECKLIST
_Be sure all items are_ ✅ _before submitting a PR for review._
* [x] Verify the linter and tests pass: `npm run review`
* [x] Verify this branch is rebased with the latest master

## GIF

![](https://media.giphy.com/media/UED88l1tXr5Je/giphy.gif)
