### PR TITLE
Adds MIT license attribution to package.json and bumps to v1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-components-modifiers",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A library that enables BEM flavored modifiers to styled components",
   "main": "dist/index.js",
   "repository": {
@@ -20,6 +20,7 @@
   "contributors": [
     "UI Platform Development Team at Decisiv, Inc."
   ],
+  "license": "MIT",
   "scripts": {
     "build": "babel lib -d dist --ignore *__tests__/",
     "build:clean": "rimraf ./dist",


### PR DESCRIPTION
## OVERVIEW
This module previously included an MIT license in the repo but this license was not referenced in`package.json`, so the license was not displayed on npmjs.org.  This PR adds the MIT license to `package.json`.

![image](https://user-images.githubusercontent.com/1790173/43803551-2a8b3e16-9a67-11e8-8bad-0ffac3331d5f.png)

## WHERE SHOULD THE REVIEWER START?

* `package.json`

## HOW CAN THIS BE MANUALLY TESTED?

N/A

## ANY NEW DEPENDENCIES ADDED?

N/A

## CHECKLIST
_Be sure all items are_ ✅ _before submitting a PR for review._
* [x] Verify the linter and tests pass: `npm run review`
* [x] Verify this branch is rebased with the latest master

## GIF

![](https://media.giphy.com/media/l0K4gA8yTvAokRsek/giphy.gif)
