### PR TITLE
Support passing modifiers as a string and remove non-string entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,28 @@ This tool allows you to implement modifiers and apply them to
 <Button modifiers={['success', 'large']}>...</Button>
 ```
 
-The modifiers are passed in as an array of flags. Each flag changes the
-appearance of the Block or Element component.
+or as a single string like this:
+
+```jsx
+<Button modifiers="success">...</Button>
+```
+
+The modifiers are passed in as an array of flags or a single flag.
+Each flag changes the appearance of the Block or Element component.
+When passing in an array, the values are filtered and only strings are used,
+which means that it is safe to do the following:
+
+```jsx
+<Button modifiers={['large', isLoading && 'loading']}>...</Button>
+```
+
+which, if `isLoading` is `false`, resolves to:
+
+```jsx
+<Button modifiers={['large', false]}>...</Button>
+```
+
+In this case only `large` will be used.
 
 ## Installation
 
@@ -188,7 +208,7 @@ function Form() {
     <div>
       {/* ...the rest of form goes here... */}
       {/* Render a button, and give it a `modifiers` prop with the desired modifiers. */}
-      <Button modifiers={['success']} />
+      <Button modifiers="success" />
     </div>
   );
 }
@@ -242,7 +262,7 @@ simple:
 ```jsx
 <Button
   responsiveModifiers={{
-    small: ['disabled'],
+    small: 'disabled',
     medium: ['success', 'large'],
   }}
   size={getTheSizeFromSomewhere()}

--- a/lib/__tests__/styleModifierPropTypes.js
+++ b/lib/__tests__/styleModifierPropTypes.js
@@ -30,7 +30,7 @@ test('styleModifierPropTypes does not log error with only valid modifiers', () =
   const testPropTypes = {
     modifiers: styleModifierPropTypes(defaultModifierConfig),
   };
-  const goodProps = { modifiers: ['defaultTest'] };
+  const goodProps = { modifiers: 'defaultTest' };
 
   PropTypes.checkPropTypes(testPropTypes, goodProps, 'prop', 'MyComponent');
 

--- a/lib/styleModifierPropTypes.js
+++ b/lib/styleModifierPropTypes.js
@@ -1,20 +1,6 @@
-import curry from 'lodash.curry';
 import keys from 'lodash.keys';
-import PropTypes from 'prop-types';
 
-const validateModifiers = curry(
-  (modifierConfig, propValue, idx, componentName, location, propFullName) => {
-    const modifierName = propValue[idx];
-    const modifierNames = keys(modifierConfig);
-    const match = modifierNames.includes(modifierName);
-    if (!match) {
-      return new Error(
-        `Invalid modifier ${modifierName} used in prop ${propFullName} and supplied to ${componentName}. Validation failed.`,
-      );
-    }
-    return true;
-  },
-);
+import normalizeModifiers from './utils/normalizeModifiers';
 
 /**
  * Evaluates the modifiers prop against the modifier config. Throw invalid proptype if a
@@ -23,5 +9,18 @@ const validateModifiers = curry(
  * @return {Boolean:Error}               Returns true or an error
  */
 export default function styleModifierPropTypes(modifierConfig) {
-  return PropTypes.arrayOf(validateModifiers(modifierConfig));
+  return (props, propName, componentName) => {
+    const modifierNames = keys(modifierConfig);
+    const modifiers = normalizeModifiers(props[propName]);
+
+    const firstInvalid = modifiers.find(name => !modifierNames.includes(name));
+
+    if (firstInvalid) {
+      return new Error(
+        `Invalid modifier ${firstInvalid} used in prop ${propName} and supplied to ${componentName}. Validation failed.`,
+      );
+    }
+
+    return undefined;
+  };
 }

--- a/lib/utils/__tests__/modifiedStyles.js
+++ b/lib/utils/__tests__/modifiedStyles.js
@@ -43,3 +43,19 @@ test('returns an empty string if modifierName is not in modifierConfig', () => {
   });
   expect(styles).toEqual('');
 });
+
+test('supports receiving the modifiers prop as a string', () => {
+  const styles = modifiedStyles('themeTest', defaultModifierConfig, {
+    theme,
+  });
+  expect(styles).toContain('background-color: black;');
+});
+
+test('filters out non String entries from the modifiers prop', () => {
+  const styles = modifiedStyles(
+    ['styleString', '', {}, [''], true, false, null, undefined],
+    defaultModifierConfig,
+    { theme },
+  );
+  expect(styles).toContain('color: blue;');
+});

--- a/lib/utils/__tests__/normalizeModifiers.js
+++ b/lib/utils/__tests__/normalizeModifiers.js
@@ -1,0 +1,19 @@
+import normalizeModifiers from '../normalizeModifiers';
+
+test('returns an array with a modifier if passed a string', () => {
+  expect(normalizeModifiers('foo')).toEqual(['foo']);
+});
+
+test('removes any non string elements from the modifiers array', () => {
+  expect(normalizeModifiers([
+    'foo',
+    '',
+    1,
+    NaN,
+    null,
+    true,
+    false,
+    undefined,
+    new Date(),
+  ])).toEqual(['foo']);
+});

--- a/lib/utils/modifiedStyles.js
+++ b/lib/utils/modifiedStyles.js
@@ -1,9 +1,12 @@
 import isFunction from 'lodash.isfunction';
 import isObject from 'lodash.isobject';
 
+import normalizeModifiers from './normalizeModifiers';
+
 /**
  * Extracts and builds the required style string based on the provided values.
- * @param {Array} modifierProps An array of strings that must match up with keys in modifierConfig
+ * @param {Array|String} modifierProps An array of strings or a single string
+ *                                     that must match up with keys in modifierConfig
  * @param {Object} modifierConfig A modifierConfig object that defines the styles
  * @param {Object} componentProps The calling component's props, used when calling the
  *                                config definitions.
@@ -13,15 +16,16 @@ export default function modifiedStyles(
   modifierConfig = {},
   componentProps = {},
 ) {
-  const stylesArr = modifierProps.reduce((acc, modifierName) => {
-    const modifierFunc = modifierConfig[modifierName];
-    if (isFunction(modifierFunc)) {
-      const config = modifierFunc(componentProps);
-      const styles = isObject(config) ? config.styles : config;
-      return acc.concat(styles);
-    }
-    return acc;
-  }, []);
+  const stylesArr = normalizeModifiers(modifierProps)
+    .reduce((acc, modifierName) => {
+      const modifierFunc = modifierConfig[modifierName];
+      if (isFunction(modifierFunc)) {
+        const config = modifierFunc(componentProps);
+        const styles = isObject(config) ? config.styles : config;
+        return acc.concat(styles);
+      }
+      return acc;
+    }, []);
 
   return stylesArr.join(' ');
 }

--- a/lib/utils/normalizeModifiers.js
+++ b/lib/utils/normalizeModifiers.js
@@ -1,0 +1,6 @@
+export default function normalizeModifiers(modifiers) {
+  return (Array.isArray(modifiers)
+    ? modifiers
+    : [modifiers]
+  ).filter(i => typeof i === 'string' && !!i);
+}


### PR DESCRIPTION
## OVERVIEW

* Allows passing a single modifier as a string: `<Comp modifiers="name" />`.
* Remove non-string entries from the modifiers array: `<Comp modifiers={['name', '', null, false]} />` becomes `<Comp modifiers={['name']} />`

## WHERE SHOULD THE REVIEWER START?

* `lib/utils/modifiedStyles.js`

## HOW CAN THIS BE MANUALLY TESTED?

Running the tests.

## ANY NEW DEPENDENCIES ADDED?

No.

## CHECKLIST

* [X] Verify the linter and tests pass: `npm run review`
* [X] Verify this branch is rebased with the latest master

## GIF

![](https://media3.giphy.com/media/3o6Zt9fevSRznTSHtK/giphy-downsized.gif?cid=6104955e5be072fc3571644d453fda3a)