### PR TITLE
ci: fixes to jest config

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "jest",
     "test:coverage:report": "open-cli coverage/lcov-report/index.html",
     "lint:ci": "eslint --format junit -o reports/junit/js-lint-results.xml src/**",
-    "test:ci": "cross-env JEST_JUNIT_OUTPUT=reports/junit/js-test-results.xml jest --ci --testResultsProcessor='./node_modules/jest-junit'"
+    "test:ci": "jest --ci"
   },
   "peerDependencies": {
     "prop-types": "^15.4.0",
@@ -78,7 +78,6 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.7.1",
     "concurrently": "^4.1.0",
-    "cross-env": "^5.0.5",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^4.2.0",
@@ -119,7 +118,16 @@
         "lines": 90,
         "statements": 90
       }
-    }
+    },
+    "reporters": [
+      "default",
+      [
+        "jest-junit",
+        {
+          "output": "reports/junit/js-test-results.xml"
+        }
+      ]
+    ]
   },
   "lint-staged": {
     "*.{js*,ts*}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1794,14 +1794,6 @@ cosmiconfig@^5.2.1:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cross-env@^5.0.5:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
-  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
-  dependencies:
-    cross-spawn "^6.0.5"
-    is-windows "^1.0.0"
-
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -3128,7 +3120,7 @@ is-what@^3.2.4:
   resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.2.4.tgz#da528659017bdd4b07892dfe4fd60da6ac500e98"
   integrity sha512-0awkPsfVd85bYStP99EqLxKvhc5SiE70hSZCPxJN2SYZ5d+IkX+r1Ri0qnPWPnuRVFrqrEnI3JgFN3yrGtjXaw==
 
-is-windows@^1.0.0, is-windows@^1.0.2:
+is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==


### PR DESCRIPTION
## OVERVIEW

Updates the jest config for CI.

## WHERE SHOULD THE REVIEWER START?

`package.json`

## HOW CAN THIS BE MANUALLY TESTED?

`yarn test:ci`

## ANY NEW DEPENDENCIES ADDED?

No.

Removed `cross-env` though since it is no longer used.

