### PR TITLE
Enhancement/proptype validation responsive modifiers size

### DIFF
--- a/src/__tests__/responsiveModifierPropTypes.js
+++ b/src/__tests__/responsiveModifierPropTypes.js
@@ -35,6 +35,7 @@ test('responsiveStyleModifierPropTypes does not log error with valid modifiers',
       XS: ['1_per_row'],
       SM: ['2_per_row', '3_per_row'],
     },
+    size: 'SM',
   };
   PropTypes.checkPropTypes(testPropTypes, goodProps, 'prop', 'MyComponent');
 
@@ -57,6 +58,7 @@ test('responsiveStyleModifierPropTypes logs error with invalid modifier key', ()
       XS: ['1_per_row', 'wrongModifier'],
       SM: ['2_per_row'],
     },
+    size: 'MD',
   };
   PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
 
@@ -83,6 +85,7 @@ test('responsiveStyleModifierPropTypes logs error with invalid modifier keys', (
       XS: ['1_per_row', 'firstWrongModifier'],
       SM: ['2_per_row', 'secondWrongModifier'],
     },
+    size: 'MD',
   };
   PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
 
@@ -110,4 +113,30 @@ test('responsiveStyleModifierPropTypes returns null if non responsiveModifiers a
   )(nonResponsiveModifiers, 'prop', 'MyComponent');
 
   expect(result).toEqual(null);
+});
+
+test('responsiveStyleModifierPropTypes logs error when no size prop is passed when using responsive modifiers', () => {
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation(noop);
+
+  const testPropTypes = {
+    responsiveModifiers: responsiveStyleModifierPropTypes(
+      defaultResponsiveModifierConfig,
+    ),
+  };
+  const badProps = {
+    responsiveModifiers: {
+      XS: '1_per_row',
+      SM: '2_per_row',
+    },
+  };
+  PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
+
+  const expectedErrMsg =
+    'Invalid Responsive Modifier; size prop must be included when using Responsive Modifiers.';
+  expect(consoleSpy).toHaveBeenCalled();
+  const errorMsg = consoleSpy.mock.calls[0][0];
+  expect(errorMsg).toContain(expectedErrMsg);
+
+  consoleSpy.mockReset();
+  consoleSpy.mockRestore();
 });

--- a/src/__tests__/responsiveModifierPropTypes.js
+++ b/src/__tests__/responsiveModifierPropTypes.js
@@ -58,7 +58,7 @@ test('responsiveStyleModifierPropTypes logs error with invalid modifier key', ()
       XS: ['1_per_row', 'wrongModifier'],
       SM: ['2_per_row'],
     },
-    size: 'MD',
+    size: 'XS',
   };
   PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
 
@@ -85,7 +85,7 @@ test('responsiveStyleModifierPropTypes logs error with invalid modifier keys', (
       XS: ['1_per_row', 'firstWrongModifier'],
       SM: ['2_per_row', 'secondWrongModifier'],
     },
-    size: 'MD',
+    size: 'XS',
   };
   PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
 

--- a/src/__tests__/responsiveModifierPropTypes.js
+++ b/src/__tests__/responsiveModifierPropTypes.js
@@ -132,10 +132,33 @@ test('responsiveStyleModifierPropTypes logs error when no size prop is passed wh
   PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
 
   const expectedErrMsg =
-    'Invalid Responsive Modifier; size prop must be included when using Responsive Modifiers.';
+    "Warning: Failed prop type: Invalid responsive prop supplied to MyComponent. Prop 'size' must be included when using responsive modifiers. Validation failed";
   expect(consoleSpy).toHaveBeenCalled();
   const errorMsg = consoleSpy.mock.calls[0][0];
   expect(errorMsg).toContain(expectedErrMsg);
+
+  consoleSpy.mockReset();
+  consoleSpy.mockRestore();
+});
+
+test('responsiveStyleModifierPropTypes will pass if any size prop is declared', () => {
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation(noop);
+
+  const testPropTypes = {
+    responsiveModifiers: responsiveStyleModifierPropTypes(
+      defaultResponsiveModifierConfig,
+    ),
+  };
+  const badProps = {
+    responsiveModifiers: {
+      XS: '1_per_row',
+      SM: '2_per_row',
+    },
+    size: undefined,
+  };
+  PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
+
+  expect(consoleSpy).not.toHaveBeenCalled();
 
   consoleSpy.mockReset();
   consoleSpy.mockRestore();

--- a/src/__tests__/styleModifierPropTypes.js
+++ b/src/__tests__/styleModifierPropTypes.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 
 import styleModifierPropTypes from '../styleModifierPropTypes';
+import responsiveStyleModifierPropTypes from '../responsiveStyleModifierPropTypes';
 
 const defaultModifierConfig = {
   test: () => ({ styles: 'display: relative;' }),
@@ -181,10 +182,31 @@ test('styleModifierPropTypes logs error when no size prop is passed when using r
   PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
 
   const expectedErrMsg =
-    'Invalid Responsive Modifier; size prop must be included when using Responsive Modifiers.';
+    "Warning: Failed prop type: Invalid responsive prop supplied to MyComponent. Prop 'size' must be included when using responsive modifiers. Validation failed";
   expect(consoleSpy).toHaveBeenCalled();
   const errorMsg = consoleSpy.mock.calls[0][0];
   expect(errorMsg).toContain(expectedErrMsg);
+
+  consoleSpy.mockReset();
+  consoleSpy.mockRestore();
+});
+
+test('styleModifierPropTypes will pass if any size prop is declared', () => {
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation(noop);
+
+  const testPropTypes = {
+    modifiers: styleModifierPropTypes(defaultModifierConfig),
+  };
+  const badProps = {
+    responsiveModifiers: {
+      XS: '1_per_row',
+      SM: '2_per_row',
+    },
+    size: undefined,
+  };
+  PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
+
+  expect(consoleSpy).not.toHaveBeenCalled();
 
   consoleSpy.mockReset();
   consoleSpy.mockRestore();

--- a/src/__tests__/styleModifierPropTypes.js
+++ b/src/__tests__/styleModifierPropTypes.js
@@ -106,6 +106,7 @@ test('styleModifierPropTypes does not log error with valid modifiers when respon
       _: ['1_per_row'],
       SM: ['2_per_row', '3_per_row'],
     },
+    size: 'SM',
   };
   PropTypes.checkPropTypes(testPropTypes, goodProps, 'prop', 'MyComponent');
 
@@ -126,6 +127,7 @@ test('styleModifierPropTypes logs error with invalid modifier key when responsiv
       XS: ['1_per_row', 'test'],
       SM: 'wrongModifier',
     },
+    size: 'MD',
   };
   PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
 
@@ -150,11 +152,36 @@ test('styleModifierPropTypes logs error with invalid modifier keys when responsi
       XS: ['1_per_row', 'firstWrongModifier'],
       SM: ['2_per_row', 'secondWrongModifier'],
     },
+    size: 'LG',
   };
   PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
 
   const expectedErrMsg =
     "Invalid modifiers firstWrongModifier, secondWrongModifier used in prop 'modifiers' (size keys XS, SM) and supplied to MyComponent. Validation failed.";
+  expect(consoleSpy).toHaveBeenCalled();
+  const errorMsg = consoleSpy.mock.calls[0][0];
+  expect(errorMsg).toContain(expectedErrMsg);
+
+  consoleSpy.mockReset();
+  consoleSpy.mockRestore();
+});
+
+test('styleModifierPropTypes logs error when no size prop is passed when using responsive modifiers', () => {
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation(noop);
+
+  const testPropTypes = {
+    modifiers: styleModifierPropTypes(defaultModifierConfig),
+  };
+  const badProps = {
+    modifiers: {
+      XS: ['1_per_row', 'test'],
+      SM: '2_per_row',
+    },
+  };
+  PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
+
+  const expectedErrMsg =
+    'Invalid Responsive Modifier; size prop must be included when using Responsive Modifiers.';
   expect(consoleSpy).toHaveBeenCalled();
   const errorMsg = consoleSpy.mock.calls[0][0];
   expect(errorMsg).toContain(expectedErrMsg);

--- a/src/__tests__/styleModifierPropTypes.js
+++ b/src/__tests__/styleModifierPropTypes.js
@@ -127,7 +127,7 @@ test('styleModifierPropTypes logs error with invalid modifier key when responsiv
       XS: ['1_per_row', 'test'],
       SM: 'wrongModifier',
     },
-    size: 'MD',
+    size: 'SM',
   };
   PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
 
@@ -152,7 +152,7 @@ test('styleModifierPropTypes logs error with invalid modifier keys when responsi
       XS: ['1_per_row', 'firstWrongModifier'],
       SM: ['2_per_row', 'secondWrongModifier'],
     },
-    size: 'LG',
+    size: 'SM',
   };
   PropTypes.checkPropTypes(testPropTypes, badProps, 'prop', 'MyComponent');
 

--- a/src/__tests__/styleModifierPropTypes.js
+++ b/src/__tests__/styleModifierPropTypes.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 
 import styleModifierPropTypes from '../styleModifierPropTypes';
-import responsiveStyleModifierPropTypes from '../responsiveStyleModifierPropTypes';
 
 const defaultModifierConfig = {
   test: () => ({ styles: 'display: relative;' }),

--- a/src/responsiveStyleModifierPropTypes.ts
+++ b/src/responsiveStyleModifierPropTypes.ts
@@ -32,6 +32,7 @@ export default function responsiveStyleModifierPropTypes(
     componentName: string,
   ): Error | null => {
     const responsiveModifiers = props[propName];
+    const sizeProp = props.size;
 
     if (isResponsiveModifiersProp(responsiveModifiers)) {
       return validateResponsiveModifiers(
@@ -39,6 +40,7 @@ export default function responsiveStyleModifierPropTypes(
         componentName,
         responsiveModifiers,
         modifierConfig,
+        sizeProp,
       );
     }
 

--- a/src/styleModifierPropTypes.ts
+++ b/src/styleModifierPropTypes.ts
@@ -88,6 +88,7 @@ function validateModifiers(
  * @param {string} componentName
  * @param {ResponsiveModifiersProp} responsiveModifiers
  * @param {ModifiersConfig} modifierConfig
+ * @param {string} sizeProp
  * @returns {Error|Null}
  */
 export function validateResponsiveModifiers(
@@ -95,10 +96,17 @@ export function validateResponsiveModifiers(
   componentName: string,
   responsiveModifiers: ResponsiveModifiersProp<ModifiersConfig, {}>,
   modifierConfig: ModifiersConfig,
+  sizeProp: string,
 ): Error | null {
   const rawInvalidModifiers: string[][] = [];
   const rawSizesWithErrors: string[] = [];
+  // eslint-disable-next-line
 
+  if (!sizeProp) {
+    return new Error(
+      'Invalid Responsive Modifier; size prop must be included when using Responsive Modifiers.',
+    );
+  }
   forIn(responsiveModifiers, (modifiers, size): void => {
     const invalidModifiers = getInvalidModifiers(
       modifiers as ModifierKeys,
@@ -144,6 +152,7 @@ export default function styleModifierPropTypes(
     componentName: string,
   ): Error | null => {
     const modifiers = props[modifiersPropName];
+    const sizeProp = props.size;
 
     if (isResponsiveModifiersProp(modifiers)) {
       return validateResponsiveModifiers(
@@ -151,6 +160,7 @@ export default function styleModifierPropTypes(
         componentName,
         modifiers,
         modifierConfig,
+        sizeProp,
       );
     }
 

--- a/src/styleModifierPropTypes.ts
+++ b/src/styleModifierPropTypes.ts
@@ -88,7 +88,7 @@ function validateModifiers(
  * @param {string} componentName
  * @param {ResponsiveModifiersProp} responsiveModifiers
  * @param {ModifiersConfig} modifierConfig
- * @param {string} sizeProp
+ * @param {boolean} sizeProp
  * @returns {Error|Null}
  */
 export function validateResponsiveModifiers(
@@ -96,17 +96,17 @@ export function validateResponsiveModifiers(
   componentName: string,
   responsiveModifiers: ResponsiveModifiersProp<ModifiersConfig, {}>,
   modifierConfig: ModifiersConfig,
-  sizeProp: string,
+  sizeProp: boolean,
 ): Error | null {
   const rawInvalidModifiers: string[][] = [];
   const rawSizesWithErrors: string[] = [];
-  // eslint-disable-next-line
 
   if (!sizeProp) {
     return new Error(
-      'Invalid Responsive Modifier; size prop must be included when using Responsive Modifiers.',
+      `Invalid responsive prop supplied to ${componentName}. Prop 'size' must be included when using responsive modifiers. Validation failed`,
     );
   }
+
   forIn(responsiveModifiers, (modifiers, size): void => {
     const invalidModifiers = getInvalidModifiers(
       modifiers as ModifierKeys,
@@ -152,7 +152,7 @@ export default function styleModifierPropTypes(
     componentName: string,
   ): Error | null => {
     const modifiers = props[modifiersPropName];
-    const sizeProp = props.size;
+    const sizeProp = Object.hasOwnProperty.call(props, 'size');
 
     if (isResponsiveModifiersProp(modifiers)) {
       return validateResponsiveModifiers(


### PR DESCRIPTION
## OVERVIEW

PR based on this open Issue:
closes https://github.com/Decisiv/styled-components-modifiers/issues/27

## WHERE SHOULD THE REVIEWER START?

`src/styleModifierPropTypes.ts`
`src/responsiveStyleModifierPropTypes.ts`

## HOW CAN THIS BE MANUALLY TESTED?

- Create a component with modifiers.
- Render the component in an application using an object syntax to declare the modifiers.
- Do not provide a size prop
- Observe no errors and no styles applied.

## ANY NEW DEPENDENCIES ADDED?

No new dependencies

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linter and tests pass: `npm run review`
- [x] Verify this branch is rebased with the latest master

## GIF

_Share a fun GIF to say thanks to your reviewer:_ https://giphy.com

![](https://media.giphy.com/media/xTiTnfkt9wCx4fuWhW/giphy.gif)
