### PR TITLE
fix: resolves default style selection bug

### DIFF
--- a/src/__tests__/applyStyleModifiers.js
+++ b/src/__tests__/applyStyleModifiers.js
@@ -54,7 +54,7 @@ test('returns a style string with styles based on size prop', () => {
   expect(styles).not.toContain('display: relative;');
 });
 
-test('returns default modifiers if size prop does not match', () => {
+test('returns default modifiers if size prop is undefined', () => {
   const props = {
     modifiers: {
       _: ['test'],
@@ -67,5 +67,21 @@ test('returns default modifiers if size prop does not match', () => {
   const styles = applyStyleModifiers(defaultModifierConfig)(props);
 
   expect(styles).toContain('display: relative;');
+  expect(styles).not.toContain('background-color: black;');
+});
+
+test('returns default modifiers if size prop does not match', () => {
+  const props = {
+    modifiers: {
+      _: ['stringTest'],
+      XS: 'themeTest',
+    },
+    size: 'SM',
+    theme,
+  };
+
+  const styles = applyStyleModifiers(defaultModifierConfig)(props);
+
+  expect(styles).toContain('color: blue;');
   expect(styles).not.toContain('background-color: black;');
 });

--- a/src/applyStyleModifiers.ts
+++ b/src/applyStyleModifiers.ts
@@ -29,16 +29,19 @@ export default function applyStyleModifiers(
       [modifiersPropName: string]: ModifiersProp<ModifiersConfig>;
     },
   ): SimpleInterpolation => {
-    const modifiers = props[modifiersPropName];
+    const modifiers = props[modifiersPropName] as ModifiersProp<
+      ModifiersConfig // eslint-disable-line @typescript-eslint/indent
+    >;
 
     if (isResponsiveModifiersProp(modifiers)) {
       return modifiedStyles(
-        (modifiers as ModifierKeys)[props.size || DEFAULT_MODIFIERS_KEY],
+        (modifiers[props.size] ||
+          modifiers[DEFAULT_MODIFIERS_KEY]) as ModifierKeys,
         modifiersConfig,
         props,
       );
     }
 
-    return modifiedStyles(modifiers, modifiersConfig, props);
+    return modifiedStyles(modifiers as ModifierKeys, modifiersConfig, props);
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export type ResponsiveModifiersProp<MC, S> = {
 /**
  * The prop passed to the component when it is rendered.
  */
-export type ModifiersProp<MC, S extends object = {}> =
+export type ModifiersProp<MC, S extends object = { [key: string]: number }> =
   | keyof MC
   | (keyof MC)[]
   | ResponsiveModifiersProp<MC, S>;


### PR DESCRIPTION
## OVERVIEW

_Give a brief description of what this PR does._
closes #40 

This PR enhances the default style selection logic to look for present modifiers, not a present size key. 

NOTE: This fix was only added to `applyStyleModifiers` because `applyResponsiveStyleModifiers` is being removed.

## WHERE SHOULD THE REVIEWER START?

_e.g. `/src/components/SomeComponent.js`_

src/applyStyleModifiers.ts

## HOW CAN THIS BE MANUALLY TESTED?

_List steps to test this locally._

The test case and the issue description outline the issue fairly clearly. Passing the tests will prove the fix.

## ANY NEW DEPENDENCIES ADDED?

_List any new dependencies added._

no

## CHECKLIST

_Be sure all items are_ ✅ _before submitting a PR for review._

- [x] Verify the linter and tests pass: `npm run review`
- [x] Verify this branch is rebased with the latest v2

## GIF

_Share a fun GIF to say thanks to your reviewer:_ https://giphy.com

![](https://media.giphy.com/media/xTiTnfkt9wCx4fuWhW/giphy.gif)
